### PR TITLE
Re-Organized/Added Details Pots & Bottles

### DIFF
--- a/data/pots_bottles.yaml
+++ b/data/pots_bottles.yaml
@@ -5,51 +5,69 @@ sections:
     title: "Cracked Pots"
     link: https://eldenring.wiki.fextralife.com/Cracked+Pot
     items:
-      - ["1_1", "Church of Elleh, Limgrave: sold by Kalé for 300 runes"]
-      - ["1_2", "Church of Elleh, Limgrave: sold by Kalé for 300 runes"]
-      - ["1_3", "Church of Elleh, Limgrave: sold by Kalé for 300 runes"]
-      - ["1_4", "Sold by Nomadic Merchant in northern Limgrave for 600 runes"]
-      - ["1_5", "Groveside Cave, Limgrave: near the entrance, on a body near wolves"]
-      - ["1_6", "Sold by Nomadic Merchant in eastern Weeping Peninsula for 600 runes"]
-      - ["1_7", "Stormveil Castle, Limgrave: amongst the Living Pots"]
-      - ["1_8", "Stormveil Castle, Limgrave: amongst the Living Pots"]
-      - ["1_9", "Jarburg, Liurnia: on a corpse by a large headstone on the southern end of town"]
-      - ["1_10", "Jarburg, Liurnia: on a corpse leaning against a building's blocked entrance on the northern end of town"]
-      - ["1_11", "Jarburg, Liurnia: in a hut just northeast of the previous"]
-      - ["1_12", "Raya Lucaria, Liurnia: up the stairs right out the door from the Debate Parlor, on a body amongst Living Pots"]
-      - ["1_13", "Caria Manor, Liurnia: left of the entrance to the boss, find a small archway in the wall to walk through; it's amongst Living Pots on the right side of the cemetery"]
-      - ["1_14", "Sold by Nomadic Merchant in southern Caelid for 1500 runes (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
-      - ["1_15", "Behind the westernmost Minor Erdtree in Caelid, on a tree branch extending from the northwest cliffs"]
-      - ["1_16", "Auriza Side Tomb, Capital Outskirts: in the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
-      - ["1_17", "Auriza Side Tomb, Capital Outskirts: in the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
-      - ["1_18", "Auriza Side Tomb, Capital Outskirts: in the gated-off watery rooms at the bottom"]
-      - ["1_19", "Auriza Side Tomb, Capital Outskirts: in the gated-off watery rooms at the bottom"]
-      - ["1_20", "Leyndell, Royal Capital: northwest of the Avenue Balcony Site of Grace and one level below, through a couple doors, on a corpse"]
+      - "Limgrave"
+      - ["1_1", "Church of Elleh, North-West of game's start: sold by Kalé for 300 runes"]
+      - ["1_2", "Church of Elleh, North-West of game's start: sold by Kalé for 300 runes"]
+      - ["1_3", "Church of Elleh, North-West of game's start: sold by Kalé for 300 runes"]
+      - ["1_4", "Groveside Cave, in cliffs North of Church of Elleh: near the entrance, on a body near wolves"]
+      - ["1_5", "East of Saintsbridge Grace in the North: Sold by Nomadic Merchant for 600 runes"]
+      - "Weeping Peninsula"
+      - ["1_6", "Castle Morne Rampart Grace: Sold by Nomadic Merchant for 600 runes"]
+      - "Stormveil"
+      - ["1_7", "On the path between Liftside Chamber Grace and Secluded Cell Grace. Amongst the Living Pots"]
+      - ["1_8", "On the path between Liftside Chamber Grace and Secluded Cell Grace. Amongst the Living Pots"]
+      - "Liurnia Lake"
+      - ["1_9", "Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on a corpse by a large headstone on the southern end of town"]
+      - ["1_10", "Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on a corpse leaning against a building's blocked entrance on the northern end of town"]
+      - ["1_11", "Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found in a hut just northeast of the previous"]
+      - ["1_12", "Caria Manor, located in the North-West: Left of the entrance to the boss, find a small archway in the wall to walk through; it's amongst Living Pots on the right side of the cemetery"]
+      - "Raya Lucaria"
+      - ["1_13", "From Debate Parlor Grace, go outside then up the stairs to the left. On a body amongst Living Pots"]
+      - "Caelid"
+      - ["1_14", "Behind the Minor Erdtree in the North-West, on a tree branch extending from the northwest cliffs"]
+      - ["1_15", "South-West of Southern Aeonia Swamp Bank Grace, South of the rot swamp. Sold by Nomadic Merchant for 1500 runes (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
+      - "Altus Plateau"
+      - ["1_16", "Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
+      - ["1_17", "Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
+      - ["1_18", "Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom"]
+      - ["1_19", "Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom"]
+      - "Leyndell"
+      - ["1_20", "Northwest of the Avenue Balcony Site of Grace and one level below, through a couple doors, on a corpse"]
   -
     title: "Ritual Pots"
     link: https://eldenring.wiki.fextralife.com/Ritual+Pot
     items:
-      - ["2_1", "Laskyar Ruins, Liurnia: near columns on the northern side"]
-      - ["2_2", "Jarburg, Liurnia: found on a rooftop only accessible as you descend the cliffside path from above"]
-      - ["2_3", "Jarburg, Liurnia: south of the previous, on a decorative jar"]
-      - ["2_4", "Raya Lucaria, Liurnia: near the Schoolhouse Classroom Site of Grace, in a chest guarded by mages and a giant Living Jar"]
-      - ["2_5", "Caria Manor, Liurnia: sold by Pidia for 1500 runes"]
-      - ["2_6", "Dragonbarrow, Caelid: sold by the Isolated Merchant for 3000 runes"]
-      - ["2_7", "Auriza Side Tomb, Capital Outskirts: in a room with a giant Living Jar"]
-      - ["2_8", "Auriza Side Tomb, Capital Outskirts: in a room with a giant Living Jar"]
-      - ["2_9", "Subterranean Shunning-Grounds, Leyndell: at the end of the maze of tunnels, just before the elevator to the Forsaken Depths"]
-      - ["2_10", "Giants' Mountaintop Catacombs, Mountaintops of the Giants: in a room with a giant Living Jar"]
+      - "Liurnia Lake"
+      - ["2_1", "Laskyar Ruins, North-West of Liurnia Lake Shore Grace: near columns on the northern side"]
+      - ["2_2", "Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on a rooftop only accessible as you descend the cliffside path from above"]
+      - ["2_3", "Jarburg, located in the East, down the cliffs just South of Carian Study Hall. South of the previous, on a decorative jar"]
+      - ["2_4", "After Caria Manor, go West of the Manor then head South. Along the cliffs on the East side, you can jump down, back into Caria manor. Sold by Pidia for 1500 runes"]
+      - "Raya Lucaria"
+      - ["2_5", "Near the Schoolhouse Classroom Site of Grace, in a chest guarded by mages and a giant Living Jar"]
+      - "Caelid"
+      - ["2_6", "Isolated Merchant's Shack in the North. Sold by the Isolated Merchant for 3000 runes"]
+      - "Altus Plateau"
+      - ["2_7", "Auriza Side Tomb, just North-East of Leyndell: In a room with a giant Living Jar"]
+      - ["2_8", "Auriza Side Tomb, just North-East of Leyndell: In a room with a giant Living Jar"]
+      - "Leyndell"
+      - ["2_9", "In the Sewers at the end of the maze of tunnels, just before the elevator to the Forsaken Depths Grace."]
+      - "Mountaintops of the Giants"
+      - ["2_10", "Giants' Mountaintop Catacombs. Follow the path North from Zamor Ruins and when you reach the fire enemies, turn around to the right to enter. In a room with a giant Living Jar."]
   -
     title: "Perfume Bottles"
     link: https://eldenring.wiki.fextralife.com/Perfume+Bottle
     items:
-      - ["3_1", "Street of Sages Ruins, Caelid: in the corner of a ruined building guarded by Miranda Sprouts and a Servant of Rot"]
-      - ["3_2", "Found north of the Altus Highway Junction Site of Grace in the Altus Plateau, on a body in the small camp near the Erdtree sapling"]
-      - ["3_3", "Perfumer's Ruins, Altus Plateau: on a body near the chest with the Perfumer's Cookbook"]
-      - ["3_4", "Perfumer's Ruins, Altus Plateau: in the back, under the Giant Miranda Sprout in the basement"]
-      - ["3_5", "Perfumer's Grotto, Altus Plateau: in a chest near the second Giant Miranda Sprout"]
-      - ["3_6", "Shaded Castle, Altus Plateau: on a body atop a wall, accessible via the second swamp ladder"]
-      - ["3_7", "Volcano Manor, Mt. Gelmir: on a body in a room unlocked with the Drawing-Room Key"]
-      - ["3_8", "Hermit Merchant's Shack, Capital Outskirts: sold by Hermit Merchant for 2000 runes"]
-      - ["3_9", "Leyndell, Royal Capital: in a chest after a ladder to the second floor of the tower next to the East Rampart"]
-      - ["3_10", "Leyndell, Royal Capital: on the east side of the eastern pond, on a body guarded by a Lesser Misbegotten"]
+      - "Caelid"
+      - ["3_1", "Street of Sages Ruins in the North-West part of the rot swamp: in the corner of a ruined building guarded by Miranda Sprouts and a Servant of Rot"]
+      - "Altus Plateau"
+      - ["3_2", "Found North of the Altus Highway Junction Site of Grace, on a body in the small camp near the Erdtree sapling"]
+      - ["3_3", "Perfumer's Grotto, East of the Altus Highway Junction: in a chest near the second Giant Miranda Sprout"]
+      - ["3_4", "Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: on a body near the chest with the Perfumer's Cookbook"]
+      - ["3_5", "Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: in the back, under the Giant Miranda Sprout in the basement"]
+      - ["3_6", "Shaded Castle, in the North-West: on a body atop a wall, accessible via the second swamp ladder"]
+      - ["3_7", "Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes"]
+      - "Mt. Gelmir"
+      - ["3_8", "Volcano Manor: on a body in a room unlocked with the Drawing-Room Key"]
+      - "Leyndell"
+      - ["3_9", "In a chest after a ladder to the second floor of the tower next to the East Capital Rampart Grace"]
+      - ["3_10", "On the East side of the Eastern pond, on a body guarded by a Lesser Misbegotten"]

--- a/data/pots_bottles.yaml
+++ b/data/pots_bottles.yaml
@@ -9,8 +9,8 @@ sections:
       - ["1_1", "Church of Elleh, North-West of game's start: sold by Kalé for 300 runes"]
       - ["1_2", "Church of Elleh, North-West of game's start: sold by Kalé for 300 runes"]
       - ["1_3", "Church of Elleh, North-West of game's start: sold by Kalé for 300 runes"]
-      - ["1_4", "Groveside Cave, in cliffs North of Church of Elleh: near the entrance, on a body near wolves"]
-      - ["1_5", "East of Saintsbridge Grace in the North: Sold by Nomadic Merchant for 600 runes"]
+      - ["1_5", "Groveside Cave, in cliffs North of Church of Elleh: near the entrance, on a body near wolves"]
+      - ["1_4", "East of Saintsbridge Grace in the North: Sold by Nomadic Merchant for 600 runes"]
       - "Weeping Peninsula"
       - ["1_6", "Castle Morne Rampart Grace: Sold by Nomadic Merchant for 600 runes"]
       - "Stormveil"
@@ -20,12 +20,12 @@ sections:
       - ["1_9", "Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on a corpse by a large headstone on the southern end of town"]
       - ["1_10", "Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on a corpse leaning against a building's blocked entrance on the northern end of town"]
       - ["1_11", "Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found in a hut just northeast of the previous"]
-      - ["1_12", "Caria Manor, located in the North-West: Left of the entrance to the boss, find a small archway in the wall to walk through; it's amongst Living Pots on the right side of the cemetery"]
+      - ["1_13", "Caria Manor, located in the North-West: Left of the entrance to the boss, find a small archway in the wall to walk through; it's amongst Living Pots on the right side of the cemetery"]
       - "Raya Lucaria"
-      - ["1_13", "From Debate Parlor Grace, go outside then up the stairs to the left. On a body amongst Living Pots"]
+      - ["1_12", "From Debate Parlor Grace, go outside then up the stairs to the left. On a body amongst Living Pots"]
       - "Caelid"
-      - ["1_14", "Behind the Minor Erdtree in the North-West, on a tree branch extending from the northwest cliffs"]
-      - ["1_15", "South-West of Southern Aeonia Swamp Bank Grace, South of the rot swamp. Sold by Nomadic Merchant for 1500 runes (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
+      - ["1_15", "Behind the Minor Erdtree in the North-West, on a tree branch extending from the northwest cliffs"]
+      - ["1_14", "South-West of Southern Aeonia Swamp Bank Grace, South of the rot swamp. Sold by Nomadic Merchant for 1500 runes (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
       - "Altus Plateau"
       - ["1_16", "Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
       - ["1_17", "Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)"]
@@ -41,9 +41,9 @@ sections:
       - ["2_1", "Laskyar Ruins, North-West of Liurnia Lake Shore Grace: near columns on the northern side"]
       - ["2_2", "Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on a rooftop only accessible as you descend the cliffside path from above"]
       - ["2_3", "Jarburg, located in the East, down the cliffs just South of Carian Study Hall. South of the previous, on a decorative jar"]
-      - ["2_4", "After Caria Manor, go West of the Manor then head South. Along the cliffs on the East side, you can jump down, back into Caria manor. Sold by Pidia for 1500 runes"]
+      - ["2_5", "After Caria Manor, go West of the Manor then head South. Along the cliffs on the East side, you can jump down, back into Caria manor. Sold by Pidia for 1500 runes"]
       - "Raya Lucaria"
-      - ["2_5", "Near the Schoolhouse Classroom Site of Grace, in a chest guarded by mages and a giant Living Jar"]
+      - ["2_4", "Near the Schoolhouse Classroom Site of Grace, in a chest guarded by mages and a giant Living Jar"]
       - "Caelid"
       - ["2_6", "Isolated Merchant's Shack in the North. Sold by the Isolated Merchant for 3000 runes"]
       - "Altus Plateau"
@@ -61,13 +61,13 @@ sections:
       - ["3_1", "Street of Sages Ruins in the North-West part of the rot swamp: in the corner of a ruined building guarded by Miranda Sprouts and a Servant of Rot"]
       - "Altus Plateau"
       - ["3_2", "Found North of the Altus Highway Junction Site of Grace, on a body in the small camp near the Erdtree sapling"]
-      - ["3_3", "Perfumer's Grotto, East of the Altus Highway Junction: in a chest near the second Giant Miranda Sprout"]
-      - ["3_4", "Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: on a body near the chest with the Perfumer's Cookbook"]
-      - ["3_5", "Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: in the back, under the Giant Miranda Sprout in the basement"]
+      - ["3_5", "Perfumer's Grotto, East of the Altus Highway Junction: in a chest near the second Giant Miranda Sprout"]
+      - ["3_3", "Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: on a body near the chest with the Perfumer's Cookbook"]
+      - ["3_4", "Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: in the back, under the Giant Miranda Sprout in the basement"]
       - ["3_6", "Shaded Castle, in the North-West: on a body atop a wall, accessible via the second swamp ladder"]
-      - ["3_7", "Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes"]
+      - ["3_8", "Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes"]
       - "Mt. Gelmir"
-      - ["3_8", "Volcano Manor: on a body in a room unlocked with the Drawing-Room Key"]
+      - ["3_7", "Volcano Manor: on a body in a room unlocked with the Drawing-Room Key"]
       - "Leyndell"
       - ["3_9", "In a chest after a ladder to the second floor of the tower next to the East Capital Rampart Grace"]
       - ["3_10", "On the East side of the Eastern pond, on a body guarded by a Lesser Misbegotten"]

--- a/index.html
+++ b/index.html
@@ -35317,16 +35317,16 @@
                     <label class="form-check-label item_content" for="pots_bottles_1_3">Church of Elleh, North-West of game's start: sold by Kalé for 300 runes</label>
                   </div>
                 </li>
-                <li class="list-group-item" data-id="pots_bottles_1_4">
-                  <div class="form-check checkbox">
-                    <input class="form-check-input" id="pots_bottles_1_4" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_4">Groveside Cave, in cliffs North of Church of Elleh: near the entrance, on a body near wolves</label>
-                  </div>
-                </li>
                 <li class="list-group-item" data-id="pots_bottles_1_5">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_5" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_5">East of Saintsbridge Grace in the North: Sold by Nomadic Merchant for 600 runes</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_5">Groveside Cave, in cliffs North of Church of Elleh: near the entrance, on a body near wolves</label>
+                  </div>
+                </li>
+                <li class="list-group-item" data-id="pots_bottles_1_4">
+                  <div class="form-check checkbox">
+                    <input class="form-check-input" id="pots_bottles_1_4" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="pots_bottles_1_4">East of Saintsbridge Grace in the North: Sold by Nomadic Merchant for 600 runes</label>
                   </div>
                 </li>
               </ul>
@@ -35374,34 +35374,34 @@
                     <label class="form-check-label item_content" for="pots_bottles_1_11">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found in a hut just northeast of the previous</label>
                   </div>
                 </li>
-                <li class="list-group-item" data-id="pots_bottles_1_12">
+                <li class="list-group-item" data-id="pots_bottles_1_13">
                   <div class="form-check checkbox">
-                    <input class="form-check-input" id="pots_bottles_1_12" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_12">Caria Manor, located in the North-West: Left of the entrance to the boss, find a small archway in the wall to walk through; it's amongst Living Pots on the right side of the cemetery</label>
+                    <input class="form-check-input" id="pots_bottles_1_13" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="pots_bottles_1_13">Caria Manor, located in the North-West: Left of the entrance to the boss, find a small archway in the wall to walk through; it's amongst Living Pots on the right side of the cemetery</label>
                   </div>
                 </li>
               </ul>
               <h5>Raya Lucaria</h5>
               <ul class="list-group-flush">
-                <li class="list-group-item" data-id="pots_bottles_1_13">
+                <li class="list-group-item" data-id="pots_bottles_1_12">
                   <div class="form-check checkbox">
-                    <input class="form-check-input" id="pots_bottles_1_13" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_13">From Debate Parlor Grace, go outside then up the stairs to the left. On a body amongst Living Pots</label>
+                    <input class="form-check-input" id="pots_bottles_1_12" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="pots_bottles_1_12">From Debate Parlor Grace, go outside then up the stairs to the left. On a body amongst Living Pots</label>
                   </div>
                 </li>
               </ul>
               <h5>Caelid</h5>
               <ul class="list-group-flush">
-                <li class="list-group-item" data-id="pots_bottles_1_14">
-                  <div class="form-check checkbox">
-                    <input class="form-check-input" id="pots_bottles_1_14" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_14">Behind the Minor Erdtree in the North-West, on a tree branch extending from the northwest cliffs</label>
-                  </div>
-                </li>
                 <li class="list-group-item" data-id="pots_bottles_1_15">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_15" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_15">South-West of Southern Aeonia Swamp Bank Grace, South of the rot swamp. Sold by Nomadic Merchant for 1500 runes (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_15">Behind the Minor Erdtree in the North-West, on a tree branch extending from the northwest cliffs</label>
+                  </div>
+                </li>
+                <li class="list-group-item" data-id="pots_bottles_1_14">
+                  <div class="form-check checkbox">
+                    <input class="form-check-input" id="pots_bottles_1_14" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="pots_bottles_1_14">South-West of Southern Aeonia Swamp Bank Grace, South of the rot swamp. Sold by Nomadic Merchant for 1500 runes (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
                   </div>
                 </li>
               </ul>
@@ -35470,19 +35470,19 @@
                     <label class="form-check-label item_content" for="pots_bottles_2_3">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. South of the previous, on a decorative jar</label>
                   </div>
                 </li>
-                <li class="list-group-item" data-id="pots_bottles_2_4">
+                <li class="list-group-item" data-id="pots_bottles_2_5">
                   <div class="form-check checkbox">
-                    <input class="form-check-input" id="pots_bottles_2_4" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_4">After Caria Manor, go West of the Manor then head South. Along the cliffs on the East side, you can jump down, back into Caria manor. Sold by Pidia for 1500 runes</label>
+                    <input class="form-check-input" id="pots_bottles_2_5" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="pots_bottles_2_5">After Caria Manor, go West of the Manor then head South. Along the cliffs on the East side, you can jump down, back into Caria manor. Sold by Pidia for 1500 runes</label>
                   </div>
                 </li>
               </ul>
               <h5>Raya Lucaria</h5>
               <ul class="list-group-flush">
-                <li class="list-group-item" data-id="pots_bottles_2_5">
+                <li class="list-group-item" data-id="pots_bottles_2_4">
                   <div class="form-check checkbox">
-                    <input class="form-check-input" id="pots_bottles_2_5" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_5">Near the Schoolhouse Classroom Site of Grace, in a chest guarded by mages and a giant Living Jar</label>
+                    <input class="form-check-input" id="pots_bottles_2_4" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="pots_bottles_2_4">Near the Schoolhouse Classroom Site of Grace, in a chest guarded by mages and a giant Living Jar</label>
                   </div>
                 </li>
               </ul>
@@ -35554,22 +35554,22 @@
                     <label class="form-check-label item_content" for="pots_bottles_3_2">Found North of the Altus Highway Junction Site of Grace, on a body in the small camp near the Erdtree sapling</label>
                   </div>
                 </li>
+                <li class="list-group-item" data-id="pots_bottles_3_5">
+                  <div class="form-check checkbox">
+                    <input class="form-check-input" id="pots_bottles_3_5" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="pots_bottles_3_5">Perfumer's Grotto, East of the Altus Highway Junction: in a chest near the second Giant Miranda Sprout</label>
+                  </div>
+                </li>
                 <li class="list-group-item" data-id="pots_bottles_3_3">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_3" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_3">Perfumer's Grotto, East of the Altus Highway Junction: in a chest near the second Giant Miranda Sprout</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_3">Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: on a body near the chest with the Perfumer's Cookbook</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_3_4">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_4" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_4">Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: on a body near the chest with the Perfumer's Cookbook</label>
-                  </div>
-                </li>
-                <li class="list-group-item" data-id="pots_bottles_3_5">
-                  <div class="form-check checkbox">
-                    <input class="form-check-input" id="pots_bottles_3_5" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_5">Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: in the back, under the Giant Miranda Sprout in the basement</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_4">Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: in the back, under the Giant Miranda Sprout in the basement</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_3_6">
@@ -35578,19 +35578,19 @@
                     <label class="form-check-label item_content" for="pots_bottles_3_6">Shaded Castle, in the North-West: on a body atop a wall, accessible via the second swamp ladder</label>
                   </div>
                 </li>
-                <li class="list-group-item" data-id="pots_bottles_3_7">
+                <li class="list-group-item" data-id="pots_bottles_3_8">
                   <div class="form-check checkbox">
-                    <input class="form-check-input" id="pots_bottles_3_7" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_7">Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes</label>
+                    <input class="form-check-input" id="pots_bottles_3_8" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="pots_bottles_3_8">Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes</label>
                   </div>
                 </li>
               </ul>
               <h5>Mt. Gelmir</h5>
               <ul class="list-group-flush">
-                <li class="list-group-item" data-id="pots_bottles_3_8">
+                <li class="list-group-item" data-id="pots_bottles_3_7">
                   <div class="form-check checkbox">
-                    <input class="form-check-input" id="pots_bottles_3_8" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_8">Volcano Manor: on a body in a room unlocked with the Drawing-Room Key</label>
+                    <input class="form-check-input" id="pots_bottles_3_7" type="checkbox" value="">
+                    <label class="form-check-label item_content" for="pots_bottles_3_7">Volcano Manor: on a body in a room unlocked with the Drawing-Room Key</label>
                   </div>
                 </li>
               </ul>

--- a/index.html
+++ b/index.html
@@ -35297,125 +35297,147 @@
               <span class="mt-0 badge rounded-pill" id="pots_bottles_totals_0"></span>
             </h4>
             <div aria-expanded="true" class="collapse show" id="pots_bottles_0Col">
+              <h5>Limgrave</h5>
               <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_1_1">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_1" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_1">Church of Elleh, Limgrave: sold by Kalé for 300 runes</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_1">Church of Elleh, North-West of game's start: sold by Kalé for 300 runes</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_2">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_2" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_2">Church of Elleh, Limgrave: sold by Kalé for 300 runes</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_2">Church of Elleh, North-West of game's start: sold by Kalé for 300 runes</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_3">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_3" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_3">Church of Elleh, Limgrave: sold by Kalé for 300 runes</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_3">Church of Elleh, North-West of game's start: sold by Kalé for 300 runes</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_4">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_4" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_4">Sold by Nomadic Merchant in northern Limgrave for 600 runes</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_4">Groveside Cave, in cliffs North of Church of Elleh: near the entrance, on a body near wolves</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_5">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_5" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_5">Groveside Cave, Limgrave: near the entrance, on a body near wolves</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_5">East of Saintsbridge Grace in the North: Sold by Nomadic Merchant for 600 runes</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Weeping Peninsula</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_1_6">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_6" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_6">Sold by Nomadic Merchant in eastern Weeping Peninsula for 600 runes</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_6">Castle Morne Rampart Grace: Sold by Nomadic Merchant for 600 runes</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Stormveil</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_1_7">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_7" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_7">Stormveil Castle, Limgrave: amongst the Living Pots</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_7">On the path between Liftside Chamber Grace and Secluded Cell Grace. Amongst the Living Pots</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_8">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_8" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_8">Stormveil Castle, Limgrave: amongst the Living Pots</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_8">On the path between Liftside Chamber Grace and Secluded Cell Grace. Amongst the Living Pots</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Liurnia Lake</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_1_9">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_9" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_9">Jarburg, Liurnia: on a corpse by a large headstone on the southern end of town</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_9">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on a corpse by a large headstone on the southern end of town</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_10">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_10" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_10">Jarburg, Liurnia: on a corpse leaning against a building's blocked entrance on the northern end of town</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_10">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on a corpse leaning against a building's blocked entrance on the northern end of town</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_11">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_11" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_11">Jarburg, Liurnia: in a hut just northeast of the previous</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_11">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found in a hut just northeast of the previous</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_12">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_12" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_12">Raya Lucaria, Liurnia: up the stairs right out the door from the Debate Parlor, on a body amongst Living Pots</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_12">Caria Manor, located in the North-West: Left of the entrance to the boss, find a small archway in the wall to walk through; it's amongst Living Pots on the right side of the cemetery</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Raya Lucaria</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_1_13">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_13" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_13">Caria Manor, Liurnia: left of the entrance to the boss, find a small archway in the wall to walk through; it's amongst Living Pots on the right side of the cemetery</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_13">From Debate Parlor Grace, go outside then up the stairs to the left. On a body amongst Living Pots</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Caelid</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_1_14">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_14" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_14">Sold by Nomadic Merchant in southern Caelid for 1500 runes (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_14">Behind the Minor Erdtree in the North-West, on a tree branch extending from the northwest cliffs</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_15">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_15" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_15">Behind the westernmost Minor Erdtree in Caelid, on a tree branch extending from the northwest cliffs</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_15">South-West of Southern Aeonia Swamp Bank Grace, South of the rot swamp. Sold by Nomadic Merchant for 1500 runes (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Altus Plateau</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_1_16">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_16" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_16">Auriza Side Tomb, Capital Outskirts: in the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_16">Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_17">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_17" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_17">Auriza Side Tomb, Capital Outskirts: in the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_17">Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom (NOTE: choosing Cracked Pots as a Keepsake gives you this pot early)</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_18">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_18" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_18">Auriza Side Tomb, Capital Outskirts: in the gated-off watery rooms at the bottom</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_18">Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_1_19">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_19" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_19">Auriza Side Tomb, Capital Outskirts: in the gated-off watery rooms at the bottom</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_19">Auriza Side Tomb, just North-East of Leyndell: In the gated-off watery rooms at the bottom</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Leyndell</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_1_20">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_1_20" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_1_20">Leyndell, Royal Capital: northwest of the Avenue Balcony Site of Grace and one level below, through a couple doors, on a corpse</label>
+                    <label class="form-check-label item_content" for="pots_bottles_1_20">Northwest of the Avenue Balcony Site of Grace and one level below, through a couple doors, on a corpse</label>
                   </div>
                 </li>
               </ul>
@@ -35428,65 +35450,81 @@
               <span class="mt-0 badge rounded-pill" id="pots_bottles_totals_1"></span>
             </h4>
             <div aria-expanded="true" class="collapse show" id="pots_bottles_1Col">
+              <h5>Liurnia Lake</h5>
               <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_2_1">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_2_1" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_1">Laskyar Ruins, Liurnia: near columns on the northern side</label>
+                    <label class="form-check-label item_content" for="pots_bottles_2_1">Laskyar Ruins, North-West of Liurnia Lake Shore Grace: near columns on the northern side</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_2_2">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_2_2" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_2">Jarburg, Liurnia: found on a rooftop only accessible as you descend the cliffside path from above</label>
+                    <label class="form-check-label item_content" for="pots_bottles_2_2">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. Found on a rooftop only accessible as you descend the cliffside path from above</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_2_3">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_2_3" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_3">Jarburg, Liurnia: south of the previous, on a decorative jar</label>
+                    <label class="form-check-label item_content" for="pots_bottles_2_3">Jarburg, located in the East, down the cliffs just South of Carian Study Hall. South of the previous, on a decorative jar</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_2_4">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_2_4" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_4">Raya Lucaria, Liurnia: near the Schoolhouse Classroom Site of Grace, in a chest guarded by mages and a giant Living Jar</label>
+                    <label class="form-check-label item_content" for="pots_bottles_2_4">After Caria Manor, go West of the Manor then head South. Along the cliffs on the East side, you can jump down, back into Caria manor. Sold by Pidia for 1500 runes</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Raya Lucaria</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_2_5">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_2_5" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_5">Caria Manor, Liurnia: sold by Pidia for 1500 runes</label>
+                    <label class="form-check-label item_content" for="pots_bottles_2_5">Near the Schoolhouse Classroom Site of Grace, in a chest guarded by mages and a giant Living Jar</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Caelid</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_2_6">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_2_6" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_6">Dragonbarrow, Caelid: sold by the Isolated Merchant for 3000 runes</label>
+                    <label class="form-check-label item_content" for="pots_bottles_2_6">Isolated Merchant's Shack in the North. Sold by the Isolated Merchant for 3000 runes</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Altus Plateau</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_2_7">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_2_7" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_7">Auriza Side Tomb, Capital Outskirts: in a room with a giant Living Jar</label>
+                    <label class="form-check-label item_content" for="pots_bottles_2_7">Auriza Side Tomb, just North-East of Leyndell: In a room with a giant Living Jar</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_2_8">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_2_8" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_8">Auriza Side Tomb, Capital Outskirts: in a room with a giant Living Jar</label>
+                    <label class="form-check-label item_content" for="pots_bottles_2_8">Auriza Side Tomb, just North-East of Leyndell: In a room with a giant Living Jar</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Leyndell</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_2_9">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_2_9" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_9">Subterranean Shunning-Grounds, Leyndell: at the end of the maze of tunnels, just before the elevator to the Forsaken Depths</label>
+                    <label class="form-check-label item_content" for="pots_bottles_2_9">In the Sewers at the end of the maze of tunnels, just before the elevator to the Forsaken Depths Grace.</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Mountaintops of the Giants</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_2_10">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_2_10" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_2_10">Giants' Mountaintop Catacombs, Mountaintops of the Giants: in a room with a giant Living Jar</label>
+                    <label class="form-check-label item_content" for="pots_bottles_2_10">Giants' Mountaintop Catacombs. Follow the path North from Zamor Ruins and when you reach the fire enemies, turn around to the right to enter. In a room with a giant Living Jar.</label>
                   </div>
                 </li>
               </ul>
@@ -35499,65 +35537,75 @@
               <span class="mt-0 badge rounded-pill" id="pots_bottles_totals_2"></span>
             </h4>
             <div aria-expanded="true" class="collapse show" id="pots_bottles_2Col">
+              <h5>Caelid</h5>
               <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_3_1">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_1" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_1">Street of Sages Ruins, Caelid: in the corner of a ruined building guarded by Miranda Sprouts and a Servant of Rot</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_1">Street of Sages Ruins in the North-West part of the rot swamp: in the corner of a ruined building guarded by Miranda Sprouts and a Servant of Rot</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Altus Plateau</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_3_2">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_2" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_2">Found north of the Altus Highway Junction Site of Grace in the Altus Plateau, on a body in the small camp near the Erdtree sapling</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_2">Found North of the Altus Highway Junction Site of Grace, on a body in the small camp near the Erdtree sapling</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_3_3">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_3" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_3">Perfumer's Ruins, Altus Plateau: on a body near the chest with the Perfumer's Cookbook</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_3">Perfumer's Grotto, East of the Altus Highway Junction: in a chest near the second Giant Miranda Sprout</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_3_4">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_4" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_4">Perfumer's Ruins, Altus Plateau: in the back, under the Giant Miranda Sprout in the basement</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_4">Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: on a body near the chest with the Perfumer's Cookbook</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_3_5">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_5" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_5">Perfumer's Grotto, Altus Plateau: in a chest near the second Giant Miranda Sprout</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_5">Perfumer's Ruins, in the far South-West, North-West from the Abandoned Coffin Grace: in the back, under the Giant Miranda Sprout in the basement</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_3_6">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_6" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_6">Shaded Castle, Altus Plateau: on a body atop a wall, accessible via the second swamp ladder</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_6">Shaded Castle, in the North-West: on a body atop a wall, accessible via the second swamp ladder</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_3_7">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_7" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_7">Volcano Manor, Mt. Gelmir: on a body in a room unlocked with the Drawing-Room Key</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_7">Hermit Merchant's Shack, on the cliff North-East from the Outer Wall Battleground Grace on the North side of the outer wall: sold by Hermit Merchant for 2000 runes</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Mt. Gelmir</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_3_8">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_8" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_8">Hermit Merchant's Shack, Capital Outskirts: sold by Hermit Merchant for 2000 runes</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_8">Volcano Manor: on a body in a room unlocked with the Drawing-Room Key</label>
                   </div>
                 </li>
+              </ul>
+              <h5>Leyndell</h5>
+              <ul class="list-group-flush">
                 <li class="list-group-item" data-id="pots_bottles_3_9">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_9" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_9">Leyndell, Royal Capital: in a chest after a ladder to the second floor of the tower next to the East Rampart</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_9">In a chest after a ladder to the second floor of the tower next to the East Capital Rampart Grace</label>
                   </div>
                 </li>
                 <li class="list-group-item" data-id="pots_bottles_3_10">
                   <div class="form-check checkbox">
                     <input class="form-check-input" id="pots_bottles_3_10" type="checkbox" value="">
-                    <label class="form-check-label item_content" for="pots_bottles_3_10">Leyndell, Royal Capital: on the east side of the eastern pond, on a body guarded by a Lesser Misbegotten</label>
+                    <label class="form-check-label item_content" for="pots_bottles_3_10">On the East side of the Eastern pond, on a body guarded by a Lesser Misbegotten</label>
                   </div>
                 </li>
               </ul>


### PR DESCRIPTION
Organized by general location, ordered by earliest to latest, and changed some locations to more thoroughly describe where they are.